### PR TITLE
Added support for placeholder slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note that `<no-ssr />` can only contain at most **ONE** child component/element.
 
 ### Placeholder
 
-Use a component or text as placeholder until `<no-ssr />` is mounted on client-side.
+Use a slot or text as placeholder until `<no-ssr />` is mounted on client-side.
 
 eg, show a loading indicator.
 
@@ -44,8 +44,13 @@ eg, show a loading indicator.
 <template>
   <div id="app">
     <h1>My Website</h1>
-    <no-ssr :placeholder="Loading">
-      <!-- this component will only be rendered on client-side -->
+    <!-- use slot -->
+    <no-ssr>
+      <comments />
+      <comments-placeholder slot="placeholder" />
+    </no-ssr>
+    <!-- or use text -->
+    <no-ssr placeholder="Loading...">
       <comments />
     </no-ssr>
   </div>
@@ -55,11 +60,6 @@ eg, show a loading indicator.
   import NoSSR from 'vue-no-ssr'
 
   export default {
-    data() {
-      return {
-        Loading: require('./Loading.vue')
-      }
-    },
     components: {
       'no-ssr': NoSSR
     }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default {
       {
         class: ['no-ssr-placeholder']
       },
-      this.placeholder
+      this.$slots.placeholder || this.placeholder
     )
   }
 }


### PR DESCRIPTION
Examples:

```html
<no-ssr placeholder="Loading...">
  <user-menu />
</no-ssr>
```

```html
<no-ssr>
  <user-menu />
  <user-menu-placeholder slot="placeholder">
</no-ssr>
```
| Text placeholder | Slot placeholder | 
|:-:|:-:|
| Loading...  | ![captura de tela de 2017-11-24 12-28-07](https://user-images.githubusercontent.com/1490347/33214415-fe2894fe-d112-11e7-9be9-2f0d873e4a82.png) |



