### PR TITLE
Allow customization of the placeholder tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ eg, show a loading indicator.
 </script>
 ```
 
+Note that the placeholder markup can be customized with the `tag` attribute (default `span`). Eg:
+
+```vue
+<no-ssr placeholder="Hi" tag="h1">
+  <h1>Hello</h1>
+</no-ssr>
+
+<!-- will render on server-side: -->
+<h1 class="no-ssr-placeholder">Hi</h1>
+
+<!-- will render on client-side: -->
+<h1>Hello</h1>
+```
+
+
 ## Development
 
 ```bash

--- a/example/App.vue
+++ b/example/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <h1>Home</h1>
-    <no-ssr placeholder="hi">
+    <no-ssr placeholder="hi" tag="h2">
       <h2>This part is rendered on the client-side only</h2>
     </no-ssr>
   </div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export default {
   name: 'no-ssr',
-  props: ['placeholder'],
+  props: ['placeholder', 'tag'],
   data() {
     return {
       canRender: false
@@ -21,7 +21,7 @@ export default {
       return this.$slots.default && this.$slots.default[0]
     }
     return h(
-      'div',
+      this.tag || 'span',
       {
         class: ['no-ssr-placeholder']
       },


### PR DESCRIPTION
_Pull Request for the issue: https://github.com/egoist/vue-no-ssr/issues/8_ 

Replace the placeholder default markup by a `span` (instead of a `div`) and allow the customization of the placeholder with the `tag` attribute.

**Exemple 1:**

```
<p><no-ssr>Lorem</no-ssr></div>
<p><span class="no-ssr-placeholder"></span></p>
```
**Exemple 2:**
```
<no-ssr placeholder="Hi" tag="h1""><h1>Title</h1></no-ssr>
<h1 class="no-ssr-placeholder">Hi</h1>
```