### PR TITLE
feat: render placeholder comment when no placeholder or or placeholder slot provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ And you get:
 </span>
 ```
 
+If prop `placeholder` is an empty string (or `null`) and no `placeholder`
+slot is found, then `<no-ssr>` will render the Vue placeholder element `<!---->`
+instead of rendering the `placholder-tag` during SSR render.
+
 ## Development
 
 ```bash

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default {
     }
   },
   render(h, { parent, slots, props }) {
-    const { default: defaultSlot, placeholder: placeholderSlot } = slots()
+    const { default: defaultSlot = [], placeholder: placeholderSlot } = slots()
 
     if (parent._isMounted) {
       return defaultSlot
@@ -29,6 +29,8 @@ export default {
       )
     }
 
-    return h(false)
+    // return a placeholder element for each child in the default slot
+    // or if no children return a single placeholder
+    return defaultSlot.length ? defaultSlot.map(() => h(false)) : h(false)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,16 @@ export default {
       parent.$forceUpdate()
     })
 
-    return h(
-      props.placeholderTag,
-      {
-        class: ['no-ssr-placeholder']
-      },
-      props.placeholder || placeholderSlot
-    )
+    if (props.placeholderTag && (props.placeholder || placeholderSlot)) {
+      return h(
+        props.placeholderTag,
+        {
+          class: ['no-ssr-placeholder']
+        },
+        props.placeholder || placeholderSlot
+      )
+    }
+
+    return h(false)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,8 @@ export default {
       )
     }
 
-    // return a placeholder element for each child in the default slot
-    // or if no children return a single placeholder
-    return defaultSlot.length ? defaultSlot.map(() => h(false)) : h(false)
+    // Return a placeholder element for each child in the default slot
+    // Or if no children return a single placeholder
+    return defaultSlot.length > 0 ? defaultSlot.map(() => h(false)) : h(false)
   }
 }


### PR DESCRIPTION
If prop `placeholder` is an empty string (or `null`), and no `placholderSlot` is found, render the Vue placeholder element (`<!--->`) during SSR render.