### PR TITLE
refactor: change component to pascal case

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'no-ssr',
+  name: 'NoSsr',
   functional: true,
   props: {
     placeholder: String,


### PR DESCRIPTION
Use pascal case so that user can use either camel or pascal case when referencing no-ssr as pascal case is recommended in [vue style guide](https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended) now.